### PR TITLE
Fix the package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tools are written as plain Go source files and loaded at runtime — no recompil
 ## Install
 
 ```
-go install github.com/user/yagi@latest
+go install github.com/yagi-agent/yagi@latest
 ```
 
 ## Usage

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattn/yagi
+module github.com/yagi-agent/yagi
 
 go 1.25.6
 


### PR DESCRIPTION
When I tried to install, I encountered an issue where `go install` was not working correctly.
The package name for `go install` listed in the README was `user/yagi`.
The name defined in `go.mod` was `mattn/yagi`.
I have uniformly changed it to `yagi-agent/yagi`.