### PR TITLE
Local Configuration Directory Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ Sessions are stored in `~/.config/yagi/sessions/` and are keyed by directory pat
 
 ## Configuration
 
+### Project-specific Configuration
+
+Yagi uses `~/.config/yagi/` as the default configuration directory.
+However, if a `.yagi/` directory exists in the current working directory, it will be used instead. This allows for project-specific configurations.
+
 ### Identity/Persona Customization
 
 You can customize the AI's behavior by specifying a custom identity file. The identity file path can be configured in three ways (in order of priority):

--- a/main.go
+++ b/main.go
@@ -181,7 +181,14 @@ func parseFlags() parsedFlags {
 	return f
 }
 
-func loadConfigurations() string {
+func resolveConfigDir() string {
+	if cwd, err := os.Getwd(); err == nil {
+		localConfig := filepath.Join(cwd, ".yagi")
+		if info, err := os.Stat(localConfig); err == nil && info.IsDir() {
+			return localConfig
+		}
+	}
+
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		u, err := user.Current()
@@ -190,7 +197,11 @@ func loadConfigurations() string {
 		}
 		configDir = filepath.Join(u.HomeDir, ".config")
 	}
-	configDir = filepath.Join(configDir, "yagi")
+	return filepath.Join(configDir, "yagi")
+}
+
+func loadConfigurations() string {
+	configDir := resolveConfigDir()
 	if err := loadConfig(configDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to load config: %v\n", err)
 	}


### PR DESCRIPTION
Hi!

I want to separate configuration directories for each project.
For example, I wanted to keep skills that are only used in a specific project grouped together.
Therefore, I changed the behavior so that if a `.yagi/` directory exists in the current directory, it is prioritized over `~/.config/yagi/`.


I also considered allowing the configuration directory to be specified via an environment variable (e.g., `YAGI_CONFIG_DIR=/path/to/project/.yagi`).
However, even if configuration via environment variables were supported, I thought it would be clearer to support non-global configuration directories by default.


Furthermore, in the future, it might be necessary to have a feature that merges files from global and local configuration directories (e.g., allowing skills from both `~/.config/yagi/skills/` and `.yagi/skills/` to be used).


Please point out any better naming conventions or smarter methods if you have them.